### PR TITLE
Add simple wallet demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Simple Wallet Demo
+
+This repository contains a minimal example of a cryptocurrency wallet using Python. The script `wallet.py` demonstrates how to:
+
+- Generate a 12-word mnemonic phrase (BIP39)
+- Derive an Ethereum address from the mnemonic
+- Check the account balance
+- Send Ether to another address
+
+The implementation relies on `web3.py` and `eth-account`. To use it, install dependencies:
+
+```bash
+pip install web3 eth-account mnemonic qrcode pillow
+```
+
+Then run:
+
+```bash
+PROVIDER_URL=https://mainnet.infura.io/v3/YOUR-PROJECT-ID python wallet.py
+```
+
+This connects to an Ethereum HTTP provider (e.g. Infura) to access the network. Replace
+`YOUR-PROJECT-ID` with your service key or use another provider.
+
+This example is for educational purposes and does not include advanced security or management features found in production wallets like Trust Wallet. Use at your own risk.
+
+## Graphical Interface
+
+`gui.py` provides a simple Tkinter GUI that lets you:
+
+- Create or recover a wallet from a 12-word phrase
+- Copy the wallet address to the clipboard
+- Display a QR code for receiving funds
+- Check the balance and send Ether
+
+Run it with the same provider environment variable:
+
+```bash
+PROVIDER_URL=https://mainnet.infura.io/v3/YOUR-PROJECT-ID python gui.py
+```

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,123 @@
+import os
+import tkinter as tk
+from tkinter import messagebox, simpledialog
+
+try:
+    import qrcode
+    from PIL import ImageTk
+except Exception:
+    qrcode = None
+    ImageTk = None
+
+from wallet import SimpleWallet
+
+
+class WalletApp:
+    def __init__(self, master):
+        self.master = master
+        master.title("Simple Wallet GUI")
+
+        provider = os.environ.get("PROVIDER_URL", "https://mainnet.infura.io/v3/YOUR-PROJECT-ID")
+        self.wallet = SimpleWallet(provider)
+        self.account = None
+        self.mnemonic = None
+
+        self.info_label = tk.Label(master, text="No wallet loaded")
+        self.info_label.pack(pady=5)
+
+        self.new_btn = tk.Button(master, text="Create New Wallet", command=self.create_wallet)
+        self.new_btn.pack(fill="x")
+
+        self.load_btn = tk.Button(master, text="Load Wallet", command=self.load_wallet)
+        self.load_btn.pack(fill="x")
+
+        self.address_label = tk.Label(master, text="")
+        self.address_label.pack(pady=5)
+
+        self.copy_btn = tk.Button(master, text="Copy Address", command=self.copy_address, state=tk.DISABLED)
+        self.copy_btn.pack(fill="x")
+
+        self.qr_btn = tk.Button(master, text="Show QR", command=self.show_qr, state=tk.DISABLED)
+        self.qr_btn.pack(fill="x")
+
+        self.balance_btn = tk.Button(master, text="Check Balance", command=self.check_balance, state=tk.DISABLED)
+        self.balance_btn.pack(fill="x")
+
+        tk.Label(master, text="Send ETH").pack(pady=(10,0))
+        self.to_entry = tk.Entry(master, width=50)
+        self.to_entry.pack(pady=2)
+        self.amount_entry = tk.Entry(master, width=20)
+        self.amount_entry.pack(pady=2)
+        self.send_btn = tk.Button(master, text="Send", command=self.send_eth, state=tk.DISABLED)
+        self.send_btn.pack(fill="x")
+
+    def create_wallet(self):
+        phrase, acct = self.wallet.create_wallet()
+        self.mnemonic = phrase
+        self.account = acct
+        messagebox.showinfo("Mnemonic", phrase)
+        self.address_label.config(text=f"Address: {acct.address}")
+        self.info_label.config(text="Wallet loaded")
+        self.enable_actions()
+
+    def load_wallet(self):
+        phrase = simpledialog.askstring("Mnemonic", "Enter your 12-word phrase")
+        if not phrase:
+            return
+        try:
+            acct = self.wallet.load_wallet(phrase)
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+            return
+        self.account = acct
+        self.mnemonic = phrase
+        self.address_label.config(text=f"Address: {acct.address}")
+        self.info_label.config(text="Wallet loaded")
+        self.enable_actions()
+
+    def enable_actions(self):
+        self.copy_btn.config(state=tk.NORMAL)
+        self.qr_btn.config(state=tk.NORMAL if qrcode and ImageTk else tk.DISABLED)
+        self.balance_btn.config(state=tk.NORMAL)
+        self.send_btn.config(state=tk.NORMAL)
+
+    def copy_address(self):
+        if self.account:
+            self.master.clipboard_clear()
+            self.master.clipboard_append(self.account.address)
+            messagebox.showinfo("Copied", "Address copied to clipboard")
+
+    def show_qr(self):
+        if not (self.account and qrcode and ImageTk):
+            messagebox.showerror("Unavailable", "QR code support not installed")
+            return
+        qr_img = qrcode.make(self.account.address)
+        top = tk.Toplevel(self.master)
+        top.title("Wallet Address QR")
+        photo = ImageTk.PhotoImage(qr_img)
+        lbl = tk.Label(top, image=photo)
+        lbl.image = photo
+        lbl.pack()
+
+    def check_balance(self):
+        if self.account:
+            bal = self.wallet.get_balance(self.account.address)
+            messagebox.showinfo("Balance", f"{bal} ETH")
+
+    def send_eth(self):
+        if not self.account:
+            return
+        to_addr = self.to_entry.get().strip()
+        amount = self.amount_entry.get().strip()
+        try:
+            value = float(amount)
+            tx_hash = self.wallet.send_eth(self.account, to_addr, value)
+            messagebox.showinfo("Transaction", tx_hash)
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
+
+if __name__ == "__main__":
+    root = tk.Tk()
+    app = WalletApp(root)
+    root.mainloop()

--- a/wallet.py
+++ b/wallet.py
@@ -1,0 +1,57 @@
+import os
+from mnemonic import Mnemonic
+from eth_account import Account
+from web3 import Web3
+
+# Required to use mnemonic-derived accounts with eth-account
+Account.enable_unaudited_hdwallet_features()
+
+
+class SimpleWallet:
+    def __init__(self, provider_url: str):
+        self.mnemo = Mnemonic('english')
+        self.provider_url = provider_url
+        self.w3 = Web3(Web3.HTTPProvider(provider_url))
+        if not self.w3.is_connected():
+            raise RuntimeError('Could not connect to provider')
+
+    def create_wallet(self):
+        """Generate a new wallet returning the mnemonic and account."""
+        phrase = self.mnemo.generate(128)
+        acct = Account.from_mnemonic(phrase)
+        return phrase, acct
+
+    def load_wallet(self, phrase: str):
+        acct = Account.from_mnemonic(phrase)
+        return acct
+
+    def get_balance(self, address: str):
+        wei_balance = self.w3.eth.get_balance(address)
+        return self.w3.from_wei(wei_balance, 'ether')
+
+    def send_eth(self, acct, to_address: str, value_eth: float, gas: int = 21000, gas_price_gwei: int = 20):
+        nonce = self.w3.eth.get_transaction_count(acct.address)
+        tx = {
+            'nonce': nonce,
+            'to': to_address,
+            'value': self.w3.to_wei(value_eth, 'ether'),
+            'gas': gas,
+            'gasPrice': self.w3.to_wei(gas_price_gwei, 'gwei')
+        }
+        signed_tx = acct.sign_transaction(tx)
+        tx_hash = self.w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        return tx_hash.hex()
+
+
+def main():
+    provider = os.environ.get('PROVIDER_URL', 'https://mainnet.infura.io/v3/YOUR-PROJECT-ID')
+    wallet = SimpleWallet(provider)
+    phrase, acct = wallet.create_wallet()
+    print('Mnemonic:', phrase)
+    print('Address:', acct.address)
+    balance = wallet.get_balance(acct.address)
+    print('Balance:', balance, 'ETH')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- enable mnemonic-derived accounts with eth-account
- return account from wallet creation and update GUI accordingly
- clarify setup instructions and provider usage

## Testing
- `python -m py_compile wallet.py gui.py`
- `php -l install.php`


------
https://chatgpt.com/codex/tasks/task_e_688cad007d708333baa071b9ef66e4f3